### PR TITLE
Migrate to libfuse3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
   run:
     - python >={{ python_min }}
-    # Ideally, we'd have a CDT dependency on libfuse here.
+    # Ideally, we'd have a CDT dependency on libfuse3 here.
 
 test:
   requires:


### PR DESCRIPTION
I've read through your recipe and believe that you mean to depend on libfuse v3 instead of v2. In an attempt to enhance compatibility accross the ecosystem, I've made libfuse v2 coinstallable with libfuse v3 by changing the name of the libfuse v3 package to libfuse3 following Ubuntu and Fedora's lead.

See https://github.com/conda-forge/libfuse-feedstock/pull/29

Please merge when you are confident these are positive changes.

@conda-forge-admin please rerender

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
